### PR TITLE
Enable shogi-bot in private channel

### DIFF
--- a/app/slack_utils/user.py
+++ b/app/slack_utils/user.py
@@ -22,8 +22,10 @@ class User:  # TODO: rename this class
                 return user["name"]
 
     def user_in_channel(self, user_id, channel_id):
-        users = self._slacker.channels.info(channel_id).body[
-            "channel"]["members"]
+        if channel_id[0] == "G":
+            users = self._slacker.groups.info(channel_id).body["group"]["members"]
+        else:
+            users = self._slacker.channels.info(channel_id).body["channel"]["members"]
         for user in users:
             if user == user_id:
                 return True

--- a/test/slack_utils/user_test.py
+++ b/test/slack_utils/user_test.py
@@ -11,6 +11,10 @@ class MockedSlacker:
         return MockedUser()
 
     @property
+    def groups(self):
+        return MockedGroup()
+
+    @property
     def channels(self):
         return MockedChannel()
 
@@ -71,10 +75,42 @@ class MockedUser:
         }
         )
 
+class MockedGroup:
+
+    def info(self, group_id):
+        if not group_id[0] == "G":
+            raise Exception()
+        return MockedBody(
+            {
+                "ok": True,
+                "group": {
+                    "id": "G023BECGF",
+                    "name": "fun",
+                    "created": 1360782804,
+                    "creator": "U024BE7LH",
+                    "is_archived": False,
+                    "is_general": False,
+                    "is_member": True,
+                    "is_starred": True,
+                    "members": [
+                            "U023BECGA",
+                    ],
+                    "topic": {},
+                    "purpose": {},
+                    "last_read": "1401383885.000061",
+                    "latest": {},
+                    "unread_count": 0,
+                    "unread_count_display": 0
+                }
+            }
+        )
 
 class MockedChannel:
 
     def info(self, channel_id):
+        if not channel_id[0] == "C":
+            raise Exception()
+        
         return MockedBody(
             {
                 "ok": True,
@@ -148,3 +184,12 @@ class UserTest(unittest.TestCase):
     def test_user_in_channel_return_False_when_user_not_exists(self):
         notexists = self.user.user_in_channel("UNONONONONO", "C023BECGA")
         self.assertFalse(notexists)
+
+    def test_user_in_privatechannel_return_True_when_user_exists(self):
+        exists = self.user.user_in_channel("U023BECGA", "G023BECGF")
+        self.assertTrue(exists)
+
+    def test_user_in_private_channel_return_False_when_user_not_exists(self):
+        notexists = self.user.user_in_channel("UNONONONONO", "G023BECGF")
+        self.assertFalse(notexists)
+        


### PR DESCRIPTION
Close #45 

Public channel is channel, but private channel is not channnel and it's a group in slack API spec.
Shogi-bot cannot move in private channel before.
After this pull request merges, shogi-bot can move in private channel.

Review me:)