### PR TITLE
Reply an appropriate error message when user want to move

### DIFF
--- a/app/modules/parse_input.py
+++ b/app/modules/parse_input.py
@@ -315,3 +315,4 @@ class ParseInput:
             if from_flag != 0:
                 return False
         return (from_x, from_y, to_x, to_y, promote, koma)
+

--- a/app/modules/shogi_input.py
+++ b/app/modules/shogi_input.py
@@ -7,6 +7,14 @@ from app.modules.shogi import Shogi as ShogiModule
 from app.modules.parse_input import ParseInput
 
 
+class UserDifferentException(Exception):
+    pass
+
+
+class KomaCannotMoveException(Exception):
+    pass
+
+
 class ShogiManager:
 
     def __init__(self):
@@ -79,25 +87,23 @@ class ShogiInput:
         shogi = ShogiInput.manager.get_shogi(channel_id)
         if shogi.first:
             if not shogi.first_user_id == user_id:
-                return False  # TODO: DifferentUserException
+                raise UserDifferentException()
         else:
             if not shogi.second_user_id == user_id:
-                return False  # TODO: DifferentUserException
+                raise UserDifferentException()
         # TODO: use Shogi object in this file and test
         movement = ParseInput.parse(movement_str, shogi.shogi)
         if not movement:
-            return False
-        else:
-            from_x, from_y, to_x, to_y, promote, koma = movement
+            raise KomaCannotMoveException()
+
+        from_x, from_y, to_x, to_y, promote, koma = movement
 
         if from_x == -1 and from_y == -1 and shogi.droppable(koma, to_x, to_y):
             shogi.drop(koma, to_x, to_y)
-            return True
         elif shogi.movable(from_x, from_y, to_x, to_y, promote):
             shogi.move(from_x, from_y, to_x, to_y, promote)
-            return True
         else:
-            return False
+            raise KomaCannotMoveException()
 
     @staticmethod
     def basic_move(channel_id, from_x, from_y, to_x, to_y, promote):
@@ -160,3 +166,4 @@ class Shogi:
     @property
     def board(self):
         return self.shogi.board
+

--- a/test/modules/shogi_input_test.py
+++ b/test/modules/shogi_input_test.py
@@ -1,6 +1,8 @@
 
 import unittest
-from app.modules.shogi_input import ShogiInput
+from app.modules.shogi_input import ShogiInput, UserDifferentException, KomaCannotMoveException
+from app.modules.shogi import Koma
+
 
 
 class ShogiTest(unittest.TestCase):
@@ -42,3 +44,51 @@ class ShogiTest(unittest.TestCase):
 
     def test_clear_for_non_exists_channnel(self):
         self.assertIsNone(ShogiInput.clear("channel_id_non_exists"))
+
+    def test_move_method_should_work(self):
+        channel_id = "test_move_method_should_work"
+        shogi = ShogiInput.init(channel_id, [{
+            "id": "user1",
+            "name": "user1name",
+        }, {
+            "id": "user2",
+            "name": "user2name",
+        }])
+
+        ShogiInput.move("76歩", channel_id, shogi.first_user_id)
+        self.assertEqual(shogi.board[5][2], Koma.fu)
+
+    def test_move_method_should_raise_UserDifferentException(self):
+        channel_id = "test_move_method_should_raise_UserDifferentException"
+        shogi = ShogiInput.init(channel_id, [{
+            "id": "user1",
+            "name": "user1name",
+        }, {
+            "id": "user2",
+            "name": "user2name",
+        }])
+
+        with self.assertRaises(UserDifferentException):
+            ShogiInput.move("76歩", channel_id, shogi.second_user_id)
+        with self.assertRaises(UserDifferentException):
+            ShogiInput.move("76歩", channel_id, "shogi.second_user_id")
+
+    def test_move_method_should_raise_KomaCannotMoveException(self):
+        channel_id = "test_move_method_should_raise_KomaCannotMoveException"
+        shogi = ShogiInput.init(channel_id, [{
+            "id": "user1",
+            "name": "user1name",
+        }, {
+            "id": "user2",
+            "name": "user2name",
+        }])
+
+        with self.assertRaises(KomaCannotMoveException):
+            ShogiInput.move("75歩", channel_id, shogi.first_user_id)
+        with self.assertRaises(KomaCannotMoveException):
+            ShogiInput.move("34歩", channel_id, shogi.first_user_id)
+        with self.assertRaises(KomaCannotMoveException):
+            ShogiInput.move("15151歩", channel_id, shogi.first_user_id)
+        with self.assertRaises(KomaCannotMoveException):
+            ShogiInput.move("Wow, it's great.", channel_id, shogi.first_user_id)
+


### PR DESCRIPTION
If user input has error, the bot reply "You cannot move this!!" before. It's not appropriate.

In this PR, I fixed a way to return error at move method in ShogiInput. It used return value for boolean to send error before. Now, It uses exception. 
To use exception, A caller can recognize each error and reply an appropriate message.