### PR TITLE
Fix 同. cannot work

### DIFF
--- a/app/modules/shogi_input.py
+++ b/app/modules/shogi_input.py
@@ -204,3 +204,11 @@ class Shogi:
     def board(self):
         return self.shogi.board
 
+    @property
+    def last_move_x(self):
+        return self.shogi.last_move_x
+
+    @property
+    def last_move_y(self):
+        return self.shogi.last_move_y
+

--- a/app/modules/shogi_input.py
+++ b/app/modules/shogi_input.py
@@ -155,7 +155,7 @@ class ShogiUser:
 class Shogi:
 
     def __init__(self, channel_id, users, validator=BasicUserValidator()):
-        self.shogi = ShogiModule()
+        self._shogi = ShogiModule()
         self.channel_id = channel_id
         self.user_ids = [x["id"] for x in users]
         random.shuffle(users)
@@ -166,20 +166,20 @@ class Shogi:
         self.kifu = Kifu()
 
     def move(self, from_x, from_y, to_x, to_y, promote):
-        self.shogi.move(from_x, from_y, to_x, to_y, promote)
+        self._shogi.move(from_x, from_y, to_x, to_y, promote)
         self.kifu.add(from_x, from_y, to_x, to_y, promote)
 
     def drop(self, koma, to_x, to_y):
-        self.shogi.drop(koma, to_x, to_y)
+        self._shogi.drop(koma, to_x, to_y)
 
     def movable(self, from_x, from_y, to_x, to_y, promote):
-        return self.shogi.movable(from_x, from_y, to_x, to_y, promote)
+        return self._shogi.movable(from_x, from_y, to_x, to_y, promote)
 
     def droppable(self, koma, to_x, to_y):
-        return self.shogi.droppable(koma, to_x, to_y)
+        return self._shogi.droppable(koma, to_x, to_y)
 
     def find_koma(self, koma):
-        return self.shogi.find_koma(koma)
+        return self._shogi.find_koma(koma)
 
     def validate(self, shogi, user_id):
         return self._validator.validate(shogi, user_id)
@@ -191,24 +191,24 @@ class Shogi:
         if len(self.kifu.kifu) == 0:
             raise KomaCannotMoveException
         self.kifu.pop()
-        self.shogi = ShogiModule()
+        self._shogi = ShogiModule()
         for kifu in self.kifu.kifu:
             from_x, from_y, to_x, to_y, promote = kifu
-            self.shogi.move(from_x, from_y, to_x, to_y, promote)
+            self._shogi.move(from_x, from_y, to_x, to_y, promote)
 
     @property
     def first(self):
-        return self.shogi.first
+        return self._shogi.first
 
     @property
     def board(self):
-        return self.shogi.board
+        return self._shogi.board
 
     @property
     def last_move_x(self):
-        return self.shogi.last_move_x
+        return self._shogi.last_move_x
 
     @property
     def last_move_y(self):
-        return self.shogi.last_move_y
+        return self._shogi.last_move_y
 

--- a/test/modules/input_parse_test.py
+++ b/test/modules/input_parse_test.py
@@ -40,7 +40,7 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("58金引", shogi), False)
         shogi.move(4, 8, 5, 7, False)
         shogi.move(5, 8, 4, 8, False)
-        shogi.shogi.first = True
+        shogi._shogi.first = True
         self.assertIn([3, 8], shogi.find_koma(Koma.kin))
         self.assertIn([4, 8], shogi.find_koma(Koma.kin))
         self.assertEqual(ParseInput.parse("58金直", shogi),
@@ -73,8 +73,8 @@ class ShogiTest(unittest.TestCase):
     def test_parse_drop(self):
         shogi = create_shogi()
         shogi.board[6][0] = Koma.empty
-        shogi.shogi.first_tegoma = [Koma.fu]
-        shogi.shogi.first = True
+        shogi._shogi.first_tegoma = [Koma.fu]
+        shogi._shogi.first = True
         self.assertEqual(ParseInput.parse("95歩打", shogi),
                          (-1, -1, 0, 4, False, Koma.fu))
         self.assertEqual(ParseInput.parse("95歩打成", shogi), False)

--- a/test/modules/input_parse_test.py
+++ b/test/modules/input_parse_test.py
@@ -40,7 +40,7 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("58金引", shogi), False)
         shogi.move(4, 8, 5, 7, False)
         shogi.move(5, 8, 4, 8, False)
-        shogi.first = True
+        shogi.shogi.first = True
         self.assertIn([3, 8], shogi.find_koma(Koma.kin))
         self.assertIn([4, 8], shogi.find_koma(Koma.kin))
         self.assertEqual(ParseInput.parse("58金直", shogi),
@@ -73,8 +73,8 @@ class ShogiTest(unittest.TestCase):
     def test_parse_drop(self):
         shogi = create_shogi()
         shogi.board[6][0] = Koma.empty
-        shogi.first_tegoma = [Koma.fu]
-        shogi.first = True
+        shogi.shogi.first_tegoma = [Koma.fu]
+        shogi.shogi.first = True
         self.assertEqual(ParseInput.parse("95歩打", shogi),
                          (-1, -1, 0, 4, False, Koma.fu))
         self.assertEqual(ParseInput.parse("95歩打成", shogi), False)

--- a/test/modules/input_parse_test.py
+++ b/test/modules/input_parse_test.py
@@ -1,7 +1,13 @@
 import unittest
-from app.modules.shogi import Shogi, Koma
+from app.modules.shogi import Koma
+from app.modules.shogi_input import Shogi
 from app.modules.parse_input import ParseInput
 
+def create_shogi():
+  return Shogi("channel_id", [
+    {"id": "user1", "name": "name1"},
+    {"id": "user2", "name": "name2"},
+  ])
 
 class ShogiTest(unittest.TestCase):
 
@@ -9,7 +15,7 @@ class ShogiTest(unittest.TestCase):
         pass
 
     def test_parse1(self):
-        shogi = Shogi()
+        shogi = create_shogi()
         self.assertEqual(ParseInput.parse("７６歩", shogi),
                          (2, 6, 2, 5, False, Koma.fu))
         self.assertEqual(ParseInput.parse("7六歩", shogi),
@@ -24,7 +30,7 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("75歩", shogi), False)
 
     def test_parse2(self):
-        shogi = Shogi()
+        shogi = create_shogi()
         self.assertEqual(ParseInput.parse("58金右", shogi),
                          (5, 8, 4, 7, False, Koma.kin))
         self.assertEqual(ParseInput.parse("58金左", shogi),
@@ -46,7 +52,7 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("58金引", shogi), False)
 
     def test_parse3(self):
-        shogi = Shogi()
+        shogi = create_shogi()
         shogi.move(2, 6, 2, 5, False)  # 76歩
         shogi.move(6, 2, 6, 3, False)  # 34歩
         self.assertEqual(ParseInput.parse("22角成", shogi),
@@ -65,7 +71,7 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("22銀成", shogi), False)
 
     def test_parse_drop(self):
-        shogi = Shogi()
+        shogi = create_shogi()
         shogi.board[6][0] = Koma.empty
         shogi.first_tegoma = [Koma.fu]
         shogi.first = True
@@ -74,19 +80,20 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("95歩打成", shogi), False)
 
     def test_parse_same(self):
-        shogi = Shogi()
+        shogi = create_shogi()
         shogi.move(2, 6, 2, 5, False)  # 76歩
         shogi.move(2, 2, 2, 3, False)  # 74歩
         shogi.move(2, 5, 2, 4, False)  # 75歩
         self.assertEqual(ParseInput.parse("同歩", shogi),
                          (2, 3, 2, 4, False, Koma.opponent_fu))
 
-        shogi = Shogi()
+        shogi = create_shogi()
         shogi.move(5, 8, 4, 1, False)  # 49の金を一気に52へ
         self.assertEqual(ParseInput.parse("同金右", shogi),
                          (3, 0, 4, 1, False, Koma.opponent_kin))
 
     @unittest.skip("see https://github.com/setokinto/slack-shogi/issues/19")
     def test_parse_ambiguous(self):
-        shogi = Shogi()
+        shogi = create_shogi()
         self.assertEqual(ParseInput.parse("58金", shogi), False)
+


### PR DESCRIPTION
同[koma_name] cannot work from #65 because last_move_x and last_move_y properties is not defined for shogi wrapper class.

- Fix test for this
- Add property for passing tests
- Make Shogi which is had by shogi wrapper private
