### PR TITLE
直/引の不具合修正

### DIFF
--- a/app/modules/parse_input.py
+++ b/app/modules/parse_input.py
@@ -306,7 +306,7 @@ class ParseInput:
             # "直"
             elif from_flag == 17:
                 for t in movable_komas:
-                    if (t[0] == to_x):
+                    if (t[0] == to_x and ((turn and t[1] > to_y) or (not turn and t[1] < to_y))):
                         from_x, from_y = t
                         from_flag = 0
                         break

--- a/app/shogi.py
+++ b/app/shogi.py
@@ -59,7 +59,7 @@ koma_names = [
 
 koma_names_string_regex = "|".join(koma_names)
 
-@respond_to("([一二三四五六七八九123456789１２３４５６７８９]{2})?(同)?(" + koma_names_string_regex + ")([上右下左寄直打]{1,2})?つ?(成)?")
+@respond_to("^([一二三四五六七八九123456789１２３４５６７８９]{2})?(同)?(" + koma_names_string_regex + ")([上右下左引寄直打]{1,2})?つ?(成)?")
 @channel_info
 @should_exist_shogi
 def koma_move(channel, message, position, dou, koma, sub_position=None, promote=None):

--- a/test/modules/input_parse_test.py
+++ b/test/modules/input_parse_test.py
@@ -92,6 +92,17 @@ class ShogiTest(unittest.TestCase):
         self.assertEqual(ParseInput.parse("同金右", shogi),
                          (3, 0, 4, 1, False, Koma.opponent_kin))
 
+    def test_parse_sugu(self):
+        shogi = create_shogi()
+        shogi.move(5, 8, 4, 7, False) # 58金
+        shogi.move(0, 2, 0, 3, False) # 94歩
+        shogi.move(3, 6, 3, 5, False) # 66歩
+        shogi.move(0, 3, 0, 4, False) # 95歩
+        shogi.move(4, 7, 3, 6, False) # 67金
+        shogi.move(0, 4, 0, 5, False) # 96歩
+        self.assertEqual(ParseInput.parse("68金直", shogi),
+                         (3, 8, 3, 7, False, Koma.kin))
+
     @unittest.skip("see https://github.com/setokinto/slack-shogi/issues/19")
     def test_parse_ambiguous(self):
         shogi = create_shogi()


### PR DESCRIPTION
不具合2点の修正です。

- "引" が動作しない
    - respond_to のマッチ条件から抜けていた
- "直" が誤動作
    - 57金/59金が存在して58金直を指定すると金引の動作になる